### PR TITLE
Vector_{erase, remove} wrong pointer casting

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ int* age_vec = vector_create();
 
 // get the vector size
 int num_ages = vector_size(age_vec); // just pass the `int*` without taking its address
+
+// insert age 18 to the 0 position in a vector
+vector_insert(age_vec, 0, 18);
 ```
 
 # Best Practices
@@ -127,8 +130,8 @@ Some functions take a normal vector argument, e.g. `vec`, while other functions 
 | free a vector                                 | `vector_free(vec_a);`                      | N/A                     |
 | add `item` to the vector `vec_a`              | `vector_add(&vec_a, item);`                | yes                     |
 | insert `item` into `vec_a` at index `9`       | `vector_insert(&vec_a, 9, item)`           | yes                     |
-| erase `4` items from `vec_a` at index `3`     | `vector_erase(&vec_a, 3, 4);`              | no (moves elements)     |
-| remove item at index `3` from `vec_a`         | `vector_remove(&vec_a, 3);`                | no (moves elements)     |
+| erase `4` items from `vec_a` at index `3`     | `vector_erase(vec_a, 3, 4);`               | no (moves elements)     |
+| remove item at index `3` from `vec_a`         | `vector_remove(vec_a, 3);`                 | no (moves elements)     |
 | get the number of items in `vec_a`            | `int num_items = vector_size(vec_a);`      | no                      |
 | get the amount of allocated memory in `vec_a` | `int alloc_amt = vector_get_alloc(vec_a);` | no                      |
 
@@ -142,8 +145,8 @@ Because the Visual Studio C compiler doesn't support the `typeof` operator, whic
 | free a vector                                 | `vector_free(vec_a);`                      | N/A                     |
 | add `item` to the vector `vec_a`              | `vector_add(&vec_a, type) = item;`         | yes                     |
 | insert `item` into `vec_a` at index `9`       | `vector_insert(&vec_a, type, 9) = item;`   | yes                     |
-| erase `4` items from `vec_a` at index `3`     | `vector_erase(&vec_a, type, 3, 4);`        | no (moves elements)     |
-| remove item at index `3` from `vec_a`         | `vector_remove(&vec_a, type, 3);`          | no (moves elements)     |
+| erase `4` items from `vec_a` at index `3`     | `vector_erase(vec_a, type, 3, 4);`         | no (moves elements)     |
+| remove item at index `3` from `vec_a`         | `vector_remove(vec_a, type, 3);`           | no (moves elements)     |
 | get the number of items in `vec_a`            | `int num_items = vector_size(vec_a);`      | no                      |
 | get the amount of allocated memory in `vec_a` | `int alloc_amt = vector_get_alloc(vec_a);` | no                      |
 

--- a/vec.h
+++ b/vec.h
@@ -50,9 +50,9 @@ typedef char* vec_char;
 
 // vec is a vector (aka type*)
 #define vector_erase(vec, pos, len)                                            \
-	(_vector_erase((vector*)vec, sizeof(*vec), pos, len))
+	(_vector_erase((vector*)&vec, sizeof(*vec), pos, len))
 #define vector_remove(vec, pos)                                                \
-	(_vector_remove((vector*)vec, sizeof(*vec), pos))
+	(_vector_remove((vector*)&vec, sizeof(*vec), pos))
 
 #define vector_copy(vec) (_vector_copy((vector*)vec, sizeof(*vec)))
 


### PR DESCRIPTION
It looks like there is wrong pointer casting in the vector_{erase, remove} macro that leads to incorrect identification of vector element size.