### PR TITLE
Add vector_clear() function to erase all items

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Some functions and macros take a normal vector argument, e.g. `vec`, while other
 | insert `item` into `vec` at index `9`   | `vector_insert(&vec, 9, item)`             | yes                     |
 | erase `4` items from `vec` at index `3` | `vector_erase(vec, 3, 4);`                 | no (moves elements)     |
 | remove item at index `3` from `vec`     | `vector_remove(vec, 3);`                   | no (moves elements)     |
+| remove last item from `vec`             | `vector_pop(vec);`                         | no                      |
+| erase all items from `vec`              | `vector_clear(vec);`                       | no                      |
 | get the number of items in `vec`        | `int size = vector_size(vec);`             | no                      |
 | get the storage capacity of `vec`       | `int capacity = vector_get_capacity(vec);` | no                      |
 | add `item` to the vector `vec`          | `type* temp = vector_add_dst(&vec);`       | yes                     |

--- a/vec.c
+++ b/vec.c
@@ -123,7 +123,7 @@ void _vector_remove(vector vec, vec_type_t type_size, vec_size_t pos)
 
 void vector_pop(vector vec) { --vector_get_header(vec)->size; }
 
-void vector_clear(vector vec) { vector_get_header(vec)->size=0; }
+void vector_clear(vector vec) { vector_get_header(vec)->size = 0; }
 
 void _vector_reserve(vector* vec_addr, vec_type_t type_size, vec_size_t capacity)
 {

--- a/vec.c
+++ b/vec.c
@@ -37,7 +37,7 @@ typedef struct
 {
 	vec_size_t size;
 	vec_size_t capacity;
-	unsigned char data[]; 
+	unsigned char data[];
 } vector_header;
 
 vector_header* vector_get_header(vector vec) { return &((vector_header*)vec)[-1]; }
@@ -122,6 +122,8 @@ void _vector_remove(vector vec, vec_type_t type_size, vec_size_t pos)
 }
 
 void vector_pop(vector vec) { --vector_get_header(vec)->size; }
+
+void vector_clear(vector vec) { vector_get_header(vec)->size=0; }
 
 void _vector_reserve(vector* vec_addr, vec_type_t type_size, vec_size_t capacity)
 {

--- a/vec.h
+++ b/vec.h
@@ -111,6 +111,8 @@ void _vector_remove(vector vec_addr, vec_type_t type_size, vec_size_t pos);
 
 void vector_pop(vector vec);
 
+void vector_clear(vector vec);
+
 void _vector_reserve(vector* vec_addr, vec_type_t type_size, vec_size_t capacity);
 
 vector _vector_copy(vector vec, vec_type_t type_size);


### PR DESCRIPTION
Hi Mashpoe !
Firstly, thanks for the lib ! 
I propose to add a function `vector_clear(vec)` to remove all items of the vector. It can be useful for backtracking algorithms, avoiding future memory allocation by reusing previous vectors...

It's ready to merge :-)

Thank you
Maxime